### PR TITLE
topsにおけるページ遷移

### DIFF
--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -25,7 +25,7 @@ class LoginController extends Controller
      *
      * @var string
      */
-    protected $redirectTo = '/home';
+    // protected $redirectTo = '/posts/index';
 
     /**
      * Create a new controller instance.
@@ -37,4 +37,11 @@ class LoginController extends Controller
         $this->middleware('guest')->except('logout');
         $this->middleware('auth')->only('logout');
     }
+
+    protected function redirectTo()
+    {
+        return route('posts.index');
+    }
 }
+
+

--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -28,7 +28,7 @@ class RegisterController extends Controller
      *
      * @var string
      */
-    protected $redirectTo = '/home';
+    // protected $redirectTo = '/home';
 
     /**
      * Create a new controller instance.
@@ -70,5 +70,10 @@ class RegisterController extends Controller
             'password' => Hash::make($data['password']),
             'tel' => $data['tel'] ?? '000-0000-0000',
         ]);
+    }
+
+    protected function redirectTo()
+    {
+        return route('tops.question');
     }
 }

--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -15,4 +15,10 @@ class PostController extends Controller
     {
         return view ('posts.create_check');
     }
+
+    public function index()
+    {
+        // 投稿一覧ページのビューを返す処理
+        return view('posts.index');
+    }
 }

--- a/app/Http/Controllers/TopController.php
+++ b/app/Http/Controllers/TopController.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+
+class TopController extends Controller
+{
+    public function index()
+    {
+        // アンケートページのビューを返す処理
+        return view('tops.question');
+    }
+}

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -14,10 +14,11 @@
                         </div>
                     @endif
 
-                    {{ __('You are logged in!') }}
+                    {{ __('新規登録完了！') }}
                 </div>
             </div>
         </div>
     </div>
+    <a href="{{ route('profile.create') }}">プロフィールを作成しましょう！</a>
 </div>
 @endsection

--- a/resources/views/posts/index.blade.php
+++ b/resources/views/posts/index.blade.php
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <title>Document</title>
+</head>
+<body>
+    <div>ログインしたら直接ここに遷移。投稿一覧画面だよ</div>
+</body>
+</html>

--- a/resources/views/tops/question.blade.php
+++ b/resources/views/tops/question.blade.php
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <title>Document</title>
+</head>
+<body>
+    <div>レジスター後直接ここに遷移。アンケートページだよ</div>
+    <a href="{{ route('home') }}">登録完了画面へ(もともとあったhomeというページに遷移します。)</a>
+</body>
+</html>

--- a/routes/web.php
+++ b/routes/web.php
@@ -8,6 +8,8 @@ use App\Http\Controllers\UserController;
 use App\Http\Controllers\PostController;
 use App\Http\Controllers\BmCoinController;
 
+use App\Http\Controllers\TopController;
+
 
 /*
 |--------------------------------------------------------------------------
@@ -40,3 +42,6 @@ Route::get('/posts/check', [PostController::class, 'show'])->name('posts.show');
 
 Route::get('/mypages/exchange', [BmCoinController::class, 'exchange'])->name('mypages.exchange');
 
+Route::get('/posts/index', [PostController::class, 'index'])->name('posts.index');
+
+Route::get('/tops/question', [TopController::class, 'index'])->name('tops.question');


### PR DESCRIPTION
login➡直接posts.indexへ遷移(postController使用)

register➡直接tops.questionへ遷移(新規作成したTopController使用)➡もともとあったログイン完了ページであるhomeを新規登録完了画面としてそこに遷移(homeController使用)➡homeにボタンを設置してtops.create_profileに遷移。

これにて、ログイン➡投稿一覧、新規登録➡初回プロフィール作成という、notionで書いている🔴topsの遷移の連結完了。

残りは初回プロフィール作成からマイページへの連結