### PR TITLE
マイページviewを返す処理作成と初回プロフィール作成からの遷移

### DIFF
--- a/app/Http/Controllers/MypageController.php
+++ b/app/Http/Controllers/MypageController.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+
+class MypageController extends Controller
+{
+    public function index()
+    {
+        // マイページのビューを返す処理
+        return view('mypages.mypage');
+    }
+}

--- a/resources/views/layouts/app_original.blade.php
+++ b/resources/views/layouts/app_original.blade.php
@@ -1,3 +1,10 @@
+<style>
+  header{
+    height: 10vh;
+    background-color: skyblue;
+  }
+</style>
+
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -7,6 +14,9 @@
   <title>PostSol 〜不満からビジネスへ〜</title>
 </head>
 <body>
+  <header>
+    <div>PostSol 〜不満からビジネスへ〜</div>
+  </header>
   @yield('content')
 </body>
 </html>

--- a/resources/views/mypages/mypage.blade.php
+++ b/resources/views/mypages/mypage.blade.php
@@ -1,0 +1,4 @@
+@extends('layouts.app_original')
+@section('content')
+    <div>初回プロフィール作成後ここに遷移。マイページだよ</div>
+@endsection

--- a/resources/views/posts/index.blade.php
+++ b/resources/views/posts/index.blade.php
@@ -1,12 +1,4 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta http-equiv="X-UA-Compatible" content="ie=edge">
-    <title>Document</title>
-</head>
-<body>
+@extends('layouts.app_original')
+@section('content')
     <div>ログインしたら直接ここに遷移。投稿一覧画面だよ</div>
-</body>
-</html>
+@endsection

--- a/resources/views/tops/create_profile.blade.php
+++ b/resources/views/tops/create_profile.blade.php
@@ -41,4 +41,5 @@
         <button type="submit">プロフィール作成</button>
         </form>
     </div>
+    <a href="{{ route('mypages.mypage') }}">マイページへ遷移</a>
 @endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -10,6 +10,7 @@ use App\Http\Controllers\BmCoinController;
 
 use App\Http\Controllers\TopController;
 
+use App\Http\Controllers\MypageController;
 
 /*
 |--------------------------------------------------------------------------
@@ -31,9 +32,9 @@ Auth::routes();
 Route::get('/home', [App\Http\Controllers\HomeController::class, 'index'])->name('home');
 
 
-Route::get('/create/profile', [UserController::class, 'create'])->name('profile.create');
+Route::get('/tops/create_profile', [UserController::class, 'create'])->name('profile.create');
 
-Route::post('/create/profile', [UserController::class, 'store'])->name('profile.store');
+Route::post('/tops/crete_profile', [UserController::class, 'store'])->name('profile.store');
 
 
 Route::get('/posts/create', [PostController::class, 'create'])->name('posts.create');
@@ -45,3 +46,5 @@ Route::get('/mypages/exchange', [BmCoinController::class, 'exchange'])->name('my
 Route::get('/posts/index', [PostController::class, 'index'])->name('posts.index');
 
 Route::get('/tops/question', [TopController::class, 'index'])->name('tops.question');
+
+Route::get('/mypages/mypage', [MypageController::class, 'index'])->name('mypages.mypage');


### PR DESCRIPTION
初回プロフィール作成ページにて、本当はプロフィール作成！というボタンを押したとき、storeとページの表示(＝index)を同時にしたい。しかし、二つの送信方法がＰＯＳＴとＧＥＴで異なるため、エラーが発生してしまう。そのため、とりあえず分離した状態の遷移方法で作成。